### PR TITLE
Update _layout.scss

### DIFF
--- a/_sass/blog/_layout.scss
+++ b/_sass/blog/_layout.scss
@@ -100,7 +100,7 @@
       &:last-child {
         margin-bottom: 10px;
       }
-      margin-right: 10px;
+      margin-right: 10px !important;
       margin-left: 10px;
     }
 


### PR DESCRIPTION
The rule for page links right margin (except last) in the media query for small screens was being overridden by the main rule. 

This made it so the links had a right margin of 20px except the last, which had a right margin of 10px, and was therefore out of alignment.

You might not have caught this in the demo because you only had two page links and it looks like they're left-aligned. In the below screenshots, I added some simulated page links to demonstrate the offset before and after the fix. 

https://imgur.com/a/ZDbXj