### PR TITLE
Finally fixing the RSS feed and SEO integration

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
     
     <title>{{ page-title }}</title>
     
-    {% if site.gems contains "jekyll-seo-tag" %}
+    {% if site.plugins contains "jekyll-seo-tag" %}
     <!-- jekyll-seo-tag -->
     {% else %}
     {% include social-metatags.html %}
@@ -36,7 +36,7 @@
     
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
     
-    {% if site.gems contains "jekyll-feed" %}
+    {% if site.plugins contains "jekyll-feed" %}
     <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | absolute_url }}">
     {% endif %}
     
@@ -112,7 +112,7 @@
                 </span>
                 
                 <!-- RSS icon -->
-                {% if site.gems contains "jekyll-feed" %}
+                {% if site.plugins contains "jekyll-feed" %}
                 <span class="my-span-icon">
                     <a href="{{ "/feed.xml" | absolute_url }}" aria-label="RSS feed" title="{{ site.github.owner_name }}'s RSS feed">
                         <svg class="my-svg-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm-3.374 17c-.897 0-1.626-.727-1.626-1.624s.729-1.624 1.626-1.624 1.626.727 1.626 1.624-.729 1.624-1.626 1.624zm3.885 0c-.03-3.022-2.485-5.474-5.511-5.504v-2.406c4.361.03 7.889 3.555 7.92 7.91h-2.409zm4.081 0c-.016-5.297-4.303-9.571-9.592-9.594v-2.406c6.623.023 11.985 5.384 12 12h-2.408z"/></svg>


### PR DESCRIPTION
Modern versions of Jekyll no longer expose the "gems" tag from the configuration file, even if it contains it. Thus, any conditional using this "gems" tag will fail. 

As seen at the bottom of https://lorepirri.github.io/cayman-blog/, where the RSS icon is clearly missing.

What's funny is that https://lorepirri.com (which I assume is using this theme ) _has_ an RSS icon at the bottom, which tells me it is either built using an old version of jekyll (and gh-pages serves a prebuilt site), or you've modified other things.

If compatibility with older versions is absolutely required, we could set it to 
`{% if site.gem contains "jekyll-seo-tag" or site.plugins contains "jekyll-seo-tag" %}`
for example.

